### PR TITLE
Expose java_string_create(JNIEnv *, const char *, size_t) publicly.

### DIFF
--- a/inc/smjni/java_string.h
+++ b/inc/smjni/java_string.h
@@ -37,6 +37,7 @@ namespace smjni
         return jattach(env, ret);
     } 
         
+    local_java_ref<jstring> java_string_create(JNIEnv * env, const char * str, size_t size);
     local_java_ref<jstring> java_string_create(JNIEnv * env, const char * str);
     local_java_ref<jstring> java_string_create(JNIEnv * env, const std::string & str);
         

--- a/src/java_string.cpp
+++ b/src/java_string.cpp
@@ -27,7 +27,7 @@ using namespace smjni;
 static thread_local std::vector<jchar> g_utf16_buffer;
 static constexpr size_t g_max_buffer_size = 64 * 1024;
 
-static local_java_ref<jstring> java_string_create(JNIEnv * env, const char * str, size_t size)
+local_java_ref<jstring> smjni::java_string_create(JNIEnv * env, const char * str, size_t size)
 {
     g_utf16_buffer.clear();
     utf8_to_utf16(str, str + size, std::back_inserter(g_utf16_buffer));

--- a/tests/src/cpp/string_tests.cpp
+++ b/tests/src/cpp/string_tests.cpp
@@ -36,6 +36,9 @@ TEST_CASE( "testString" )
     auto str3 = java_string_create(env, std::string("hello"));
     CHECK(5 == java_string_get_length(env, str3));
     CHECK("hello" == java_string_to_cpp(env, str3));
+    auto str4 = java_string_create(env, "hello world", 5);
+    CHECK(5 == java_string_get_length(env, str4));
+    CHECK("hello" == java_string_to_cpp(env, str4));
 
     auto empty = java_string_create(env, nullptr);
     CHECK(0 == java_string_get_length(env, empty));


### PR DESCRIPTION
I'm JNI-bridging a library (Abseil, used in WebRTC) that has a type (StringView) with non-NUL-terminated C strings, so this function is useful as part of the public API, and I don't see any reason it shouldn't be exposed.